### PR TITLE
Add a proto to 'extends' to allow bare package names

### DIFF
--- a/lib/Mo.pm
+++ b/lib/Mo.pm
@@ -1,3 +1,3 @@
 package Mo;
 $VERSION=0.25;
-no warnings;my$K=__PACKAGE__."::";*{$K.'Object::new'}=sub{my$c=shift;my$s=bless{@_},$c;my@B;do{@B=($c.'::BUILD',@B)}while($c)=@{$c.'::ISA'};exists&$_&&&$_($s)for@B;$s};*{$K.'import'}=sub{import warnings;$^H|=1538;my$P=caller."::";my%e=(extends=>sub{eval"no $_[0]()";@{$P.'ISA'}=$_[0]},has=>sub{my$n=shift;*{$P.$n}=sub{$#_?$_[0]{$n}=$_[1]:$_[0]{$n}}},);for(@_[1..$#_]){eval"require Mo::$_;1";%e=&{$K."${_}::e"}($P=>%e)}*{$P.$_}=$e{$_}for keys%e;@{$P.'ISA'}=$K.'Object'};
+no warnings;my$K=__PACKAGE__."::";*{$K.'Object::new'}=sub{my$c=shift;my$s=bless{@_},$c;my@B;do{@B=($c.'::BUILD',@B)}while($c)=@{$c.'::ISA'};exists&$_&&&$_($s)for@B;$s};*{$K.'import'}=sub{import warnings;$^H|=1538;my$P=caller."::";my%e=(extends=>sub(*){eval"no $_[0]()";@{$P.'ISA'}=$_[0]},has=>sub{my$n=shift;*{$P.$n}=sub{$#_?$_[0]{$n}=$_[1]:$_[0]{$n}}},);for(@_[1..$#_]){eval"require Mo::$_;1";%e=&{$K."${_}::e"}($P=>%e)}*{$P.$_}=$e{$_}for keys%e;@{$P.'ISA'}=$K.'Object'};

--- a/src/Mo.pm
+++ b/src/Mo.pm
@@ -24,7 +24,7 @@ my $MoPKG = __PACKAGE__."::";
     $^H |= 1538;
     my $caller_pkg = caller."::";
     my %exports = (
-        extends => sub {
+        extends => sub(*){
             eval "no $_[0]" . "()";
             @{ $caller_pkg . 'ISA' } = $_[0];
         },

--- a/t/Baz.pm
+++ b/t/Baz.pm
@@ -1,0 +1,6 @@
+package Baz;
+use strict;
+use warnings;
+use Mo;
+extends Foo;
+1;

--- a/t/Goo.pm
+++ b/t/Goo.pm
@@ -1,0 +1,6 @@
+package Goo;
+use strict;
+use warnings;
+use Mo;
+extends Foo::;
+1;

--- a/t/extends.t
+++ b/t/extends.t
@@ -1,13 +1,18 @@
-use Test::More tests => 4;
+use Test::More tests => 15;
 
 use lib 't';
 use Bar;
+use Baz;
+use Goo;
 
-my $b = Bar->new;
+foreach my $class (qw<Bar Baz Goo>) {
+    my $b = $class->new;
 
-ok $b->isa('Foo'), 'Bar is a subclass of Foo';
+    isa_ok $b, $class;
+    isa_ok $b, 'Foo';
 
-is "@Bar::ISA", "Foo", 'Extends with multiple classes not supported';
+    is "@Bar::ISA", "Foo", 'Extends with multiple classes not supported';
 
-ok 'Foo'->can('stuff'), 'Foo is loaded';
-ok not('Bar'->can('buff')), 'Boo is not loaded';
+    ok 'Foo'->can('stuff'), 'Foo is loaded';
+    ok not('Bar'->can('buff')), 'Boo is not loaded';
+}


### PR DESCRIPTION
Add a proto to the extends sub to allow bare names ("extends Foo"
or "extends Foo::" in addition to "extends 'Foo'").
See tests (t/Baz.pm, t/Goo.pm).
