### PR TITLE
RFC: Make sure extends() dies if we fail to load the parent package

### DIFF
--- a/lib/Mo.pm
+++ b/lib/Mo.pm
@@ -1,3 +1,3 @@
 package Mo;
 $VERSION='0.30';
-no warnings;my$M=__PACKAGE__.::;*{$M.Object::new}=sub{bless{@_[1..$#_]},$_[0]};*{$M.import}=sub{import warnings;$^H|=1538;my($P,%e,%o)=caller.::;shift;eval"no Mo::$_",&{$M.$_.::e}($P,\%e,\%o,\@_)for@_;return if$e{M};%e=(extends,sub{eval"no $_[0]()";@{$P.ISA}=$_[0]},has,sub{my$n=shift;my$m=sub{$#_?$_[0]{$n}=$_[1]:$_[0]{$n}};$m=$o{$_}->($m,$n,@_)for sort keys%o;*{$P.$n}=$m},%e,);*{$P.$_}=$e{$_}for keys%e;@{$P.ISA}=$M.Object};
+no warnings;my$M=__PACKAGE__.::;*{$M.Object::new}=sub{bless{@_[1..$#_]},$_[0]};*{$M.import}=sub{import warnings;$^H|=1538;my($P,%e,%o)=caller.::;shift;eval"no Mo::$_",&{$M.$_.::e}($P,\%e,\%o,\@_)for@_;(my$file=$P)=~s/::$/.pm/;$file=~s/::/\//g;$INC{$file}||=(caller)[1];return if$e{M};%e=(extends,sub{eval"no $_[0](); 1"||die;@{$P.ISA}=$_[0]},has,sub{my$n=shift;my$m=sub{$#_?$_[0]{$n}=$_[1]:$_[0]{$n}};$m=$o{$_}->($m,$n,@_)for sort keys%o;*{$P.$n}=$m},%e,);*{$P.$_}=$e{$_}for keys%e;@{$P.ISA}=$M.Object};

--- a/src/Mo.pm
+++ b/src/Mo.pm
@@ -30,10 +30,15 @@ my $MoPKG = __PACKAGE__.::;
             \%options,
             \@_
         ) for @_;
+
+    (my $file = $caller_pkg) =~ s/::$/.pm/;
+    $file =~ s/::/\//g;
+    $INC{$file} ||= (caller)[1];
+
     return if $exports{M}; 
     %exports = (
         extends, sub {
-            eval "no $_[0]()";
+            eval "no $_[0](); 1" || die;
             @{ $caller_pkg . ISA } = $_[0];
         },
         has, sub {

--- a/t/extends.t
+++ b/t/extends.t
@@ -1,4 +1,4 @@
-use Test::More tests => 4;
+use Test::More tests => 5;
 
 use lib 't';
 use Bar;
@@ -11,3 +11,6 @@ is "@Bar::ISA", "Foo", 'Extends with multiple classes not supported';
 
 ok 'Foo'->can('stuff'), 'Foo is loaded';
 ok not('Bar'->can('buff')), 'Boo is not loaded';
+
+eval { require Oops };
+ok $@, 'Bad class in extends() dies';


### PR DESCRIPTION
If the package in extends() fails to load (either because of a typo or a syntax error), Mo silently ignores this and keeps going. This changes make extends() propagate the error message that `no PACKAGE ()` generates.

OTOH this makes inline classes (like those used on `t/build.t` and `t/test.t`) stop working because inline classes don't update %INC and so a follow up extends() in a child class would die with "Cannot find PACKAGE.pm".

We changed Mo::import() to update %INC if needed. This may have other consequences that I'm not thinking about right now. If so, please suggest an alternative to support inline classes, I will update my branch with it.

Signed-off-by: Pedro Melo melo@simplicidade.org
