### PR TITLE
Accepts 0 and undef as values on required attributes

### DIFF
--- a/lib/Mo/required.pm
+++ b/lib/Mo/required.pm
@@ -1,3 +1,3 @@
 package Mo::required;my$M="Mo::";
 $VERSION=0.31;
-*{$M.'required::e'}=sub{my($P,$e,$o)=@_;$o->{required}=sub{my($m,$n,%a)=@_;if($a{required}){my$C=*{$P."new"}{CODE}||*{$M.Object::new}{CODE};no warnings 'redefine';*{$P."new"}=sub{my$s=$C->(@_);my%a=@_[1..$#_];die$n." required"if!$a{$n};$s}}$m}};
+*{$M.'required::e'}=sub{my($P,$e,$o)=@_;$o->{required}=sub{my($m,$n,%a)=@_;if($a{required}){my$C=*{$P."new"}{CODE}||*{$M.Object::new}{CODE};no warnings 'redefine';*{$P."new"}=sub{my$s=$C->(@_);my%a=@_[1..$#_];die$n." required"if!exists$a{$n};$s}}$m}};

--- a/src/Mo/required.pm
+++ b/src/Mo/required.pm
@@ -13,7 +13,7 @@ $VERSION = 0.31;
             *{$caller_pkg."new"} = sub {
                 my $self = $old_constructor->(@_);
                 my %args = @_[1..$#_];
-                die $name." required" if !$args{$name};
+                die $name." required" if !exists $args{$name};
                 $self;
             };
         }

--- a/t/required.t
+++ b/t/required.t
@@ -1,6 +1,6 @@
 use Test::More;
 
-plan tests => 3;
+plan tests => 5;
 
 #============
 package Foo::required;
@@ -23,6 +23,10 @@ like $@, qr/^stuff required/, 'Mo dies when a required value is not provided';
 
 my $f = Foo::required->new(stuff => 'fubar', stuff2 => 'foobar');
 is $f->stuff, 'fubar', 'Object is correctly initialized when required values are provided';
+
+my $f1 = Foo::required->new(stuff => undef, stuff2 => 0);
+is $f1->stuff, undef, 'Required parameters can be undef';
+is $f1->stuff2, 0, 'Required parameters can be 0';
 
 my $f2 = Foo::required_is->new(stuff => 'fubar');
 is $f2->stuff, 'fubar', 'Object is correctly initialized when required is combined with is';


### PR DESCRIPTION
This is a simple !$args{$name} => !exists $args{$name} replacement

Let me know if you'd like it in a different way and I'd be more than happy to fix :)
