### PR TITLE
default dies if not given a coderef

### DIFF
--- a/lib/Mo/default.pm
+++ b/lib/Mo/default.pm
@@ -1,3 +1,3 @@
 package Mo::default;my$M="Mo::";
 $VERSION=0.31;
-*{$M.'default::e'}=sub{my($P,$e,$o)=@_;$o->{default}=sub{my($m,$n,%a)=@_;$a{default}or return$m;sub{$#_?$m->(@_):!exists$_[0]{$n}?$_[0]{$n}=$a{default}->(@_):$m->(@_)}}};
+*{$M.'default::e'}=sub{my($P,$e,$o)=@_;$o->{default}=sub{my($m,$n,%a)=@_;exists$a{default}or return$m;die$n.' not a code ref'if ref($a{default})ne 'CODE';sub{$#_?$m->(@_):!exists$_[0]{$n}?$_[0]{$n}=$a{default}->(@_):$m->(@_)}}};

--- a/src/Mo/default.pm
+++ b/src/Mo/default.pm
@@ -6,7 +6,8 @@ $VERSION = 0.31;
     my ($caller_pkg, $exports, $options) = @_;
     $options->{default} = sub {
         my ($method, $name, %args) = @_;
-        $args{default} or return $method;
+        exists $args{default} or return $method;
+        die $name.' not a code ref' if ref($args{default}) ne 'CODE';
         sub {
             $#_
               ? $method->(@_)

--- a/t/default.t
+++ b/t/default.t
@@ -1,0 +1,40 @@
+use Test::More tests => 10;
+
+is(
+    eval {
+        package Foo;
+        use Mo qw(default);
+        has fooz => ( default => 123 );
+        1;
+    },
+    undef,
+    'default dies when not given coderef'
+);
+like $@, qr/fooz not a code ref/, '.. dies with clear error message';
+
+is(
+    eval {
+        package Bar;
+        use Mo qw(default);
+        has baz => ( default => 0 );
+        1;
+    },
+    undef,
+    'default dies when not given coderef even when passed 0'
+);
+like $@, qr/baz not a code ref/, '.. dies with clear error message';
+
+package Baz;
+use Mo qw(default);
+has baz   => ( default => sub { 123 } );
+has bazed => ( default => sub { 0 } );
+
+package main;
+
+my $foo = new_ok('Baz');
+is $foo->baz,   123,   'used default value';
+is $foo->bazed, 0, '0 as default is valid';
+
+$foo = new_ok( 'Baz', [ baz => 'changed', bazed => 'none' ] );
+is $foo->baz,   'changed', 'default can be overriden';
+is $foo->bazed, 'none',    'default can be overriden';


### PR DESCRIPTION
This is mostly to avoid mistakenly doing
has attr => (default => 0);

and sillently getting $foo->attr as undef instead.

About tests, I'm aware there was already some tests for default on t/test.t but that seemed to be doing other things too, so I thought it would be better to have a t/default.t with default specific cases.

Let me know if you'd prefer anything differently.
