### PR TITLE
Disambiguate a parsing problem under some versions of Perl.

### DIFF
--- a/lib/Mo/nonlazy.pm
+++ b/lib/Mo/nonlazy.pm
@@ -1,3 +1,3 @@
 package Mo::nonlazy;my$M="Mo::";
 $VERSION=0.38;
-*{$M.'nonlazy::e'}=sub{${shift.':N'}=1};
+*{$M.'nonlazy::e'}=sub{${shift().':N'}=1};

--- a/src/Mo/nonlazy.pm
+++ b/src/Mo/nonlazy.pm
@@ -3,5 +3,5 @@ my $MoPKG = "Mo::";
 $VERSION=0.38;
 
 *{ $MoPKG . 'nonlazy::e' } = sub {
-    ${ shift . NONLAZY } = 1;
+    ${ shift() . NONLAZY } = 1;
 };


### PR DESCRIPTION
Under 5.10.1 "shift . ':N'" is considered ambiguous, and generates a warning.  Adding parens to the shift call disambiguates the parsing, and the warning isn't tripped.

Note: This patch doesn't touch "Changes".  This will need to be done prior to release.
