### PR TITLE
Escape :: to avoid weird bug

### DIFF
--- a/src/Mo.pm
+++ b/src/Mo.pm
@@ -14,7 +14,7 @@ my $MoPKG = __PACKAGE__.'::';
 *{$MoPKG.Object::new} = sub {
     my $class            = shift;
     my $self             = bless {@_}, $class;
-    my %nonlazy_defaults = %{ $class . :: . EAGERINIT };
+    my %nonlazy_defaults = %{ $class . '::' . EAGERINIT };
     map { $self->{$_} = $nonlazy_defaults{$_}->() if !exists $self->{$_} }
       keys %nonlazy_defaults;
     $self


### PR DESCRIPTION
I think this is the same bug from PR #16. Basically, using the latest
YAML release (1.16), I can run this test script and trigger the bug:

    use strict;
    use warnings;

    use Module::Runtime 'use_module';
    use Safe;

    my $safe = Safe->new;

    use_module('YAML');

    print YAML::Dump( { yarr => 1 } );

Resulting in:

    mo-pm git:bugfix-issue_24 ❯ perl test2.pl
    Undefined subroutine &main::main:: called at /home/ad/nigelg/.plenv/versions/new5203/lib/perl5/site_perl/5.20.3/YAML/Mo.pm line 5.

After rebuilding Mo and running mo-inline on YAML/Mo.pm, I get:

    mo-pm git:bugfix-issue_24 ❯ perl test2.pl
    ---
    yarr: 1