### PR TITLE
Extend main_sub test to call constructor

### DIFF
--- a/t/main_sub.t
+++ b/t/main_sub.t
@@ -3,8 +3,10 @@ use Test::More;
 no warnings;
 \&::main::;
 
-plan tests => 1;
+plan tests => 2;
 
 eval 'use Mo';
+ok !$@, 'use Mo works with global sub called "" ' . ($@||'');
 
-ok !$@, 'Mo works with global sub called "" ' . ($@||'');
+eval 'Mo->import; main->new';
+ok !$@, 'Mo->new works with global sub called "" ' . ($@||'');


### PR DESCRIPTION
Issue #24 noted an Undefined subroutine &main::main:: error that needed
tests and a patch. #30 has a patch; and here's a simple test to tickle it.

@ingydotnet any change for a quick review and release to resolve the YAML::Mo issues too ?