### PR TITLE
Replace EOLTests with Test::EOL

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -47,7 +47,7 @@ package = DB    ; just in case
 [ExtraTests]
 [RunExtraTests]
 [NoTabsTests]
-[EOLTests]
+[Test::EOL]
 [Test::Version]
 [MetaTests]
 [CheckMetaResources]

--- a/lib/Mo.pod
+++ b/lib/Mo.pod
@@ -86,7 +86,7 @@ couple more features. Don't worry. Mo's got you covered:
     }
 
 Mo simply loads the feature classes L<Mo::build>, L<Mo::default>,
-L<Mo::builder>, L<Mo::coerce>, L<Mo::is> and L<Mo::required>. 
+L<Mo::builder>, L<Mo::coerce>, L<Mo::is> and L<Mo::required>.
 The first one supports BUILD constructing and the other three
 add their magics to C<has>. A L<Mo::Feature> module can enhance C<new>,
 C<extends> and C<has>, and also add new export subs, or remove existing ones.

--- a/lib/Mo/Design.pod
+++ b/lib/Mo/Design.pod
@@ -67,7 +67,7 @@ documentation. See C<Mo::Inline>.
 
 L<Moose> has become the accepted style of OO in perl. Mo will attempt to not
 do the things it does in an incompatible style to the C<Moose> family.
-    
+
 This is not to say that all Mo code can be switched to Moo, or vice versa.
 This I<is> to say that you should be able to find a style of coding using the
 full capabilities of Mo, that you can switch to L<Moo> (or L<Mouse> or L<Moose>),

--- a/lib/Mo/exports.pod
+++ b/lib/Mo/exports.pod
@@ -7,7 +7,7 @@ Mo::exporter - Export the @EXPORT list
 =head1 Synopsis
 
     package MyMo;
-    # use Mo qw[exporter import]; 
+    # use Mo qw[exporter import];
 
     package SomeClass;
     use MyMo;

--- a/lib/Mo/import.pod
+++ b/lib/Mo/import.pod
@@ -7,7 +7,7 @@ Mo::import - Special import feature for Mo::Inline
 =head1 Synopsis
 
     package MyMo;
-    # use Mo qw[default builder import]; 
+    # use Mo qw[default builder import];
 
     package SomeClass;
     use MyMo;

--- a/lib/Mo/importer.pod
+++ b/lib/Mo/importer.pod
@@ -13,7 +13,7 @@ Mo::importer - Write your own import() extension
         ...
     }
 
-    use Mo qw[importer other features]; 
+    use Mo qw[importer other features];
 
 =head1 Description
 

--- a/lib/Mo/is.pod
+++ b/lib/Mo/is.pod
@@ -12,7 +12,7 @@ Mo::is - Adds the is feature to Mo's has
 =head1 Description
 
 Adds the is parameter to has. If you set it to I<ro>, the accessor
-will only work as a getter. You will still able to set the value 
+will only work as a getter. You will still able to set the value
 at construction time via C<new>.
 
 =cut

--- a/lib/Mo/required.pod
+++ b/lib/Mo/required.pod
@@ -11,7 +11,7 @@ Mo::required - Adds the required feature to Mo's has
 
 =head1 Description
 
-Adds the required parameter to has. When required is set to a positive 
+Adds the required parameter to has. When required is set to a positive
 value, the constructor will die if the attribute is not set.
 
 =cut


### PR DESCRIPTION
The `EOLTests` `Dist::Zilla` plugin is deprecated and may be removed in the future.  The recommended alternative is `Test::EOL` which is what has been used here.  The files with trailing whitespace have been corrected and the end-of-line character tests now pass correctly.

This pull request is submitted in the hope that it is helpful.  If you have any questions or comments regarding it, please don't hesitate to let me know.