### PR TITLE
Replace deprecated dzil plugins

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,8 @@ run = make -C src/ version all  ; re-sync version declarations before re-minifyi
 [@Filter]
 -bundle = @INGY
 -remove = Git::NextVersion
+-remove = ReportVersions::Tiny
+[Test::ReportPrereqs]
 
 
 Git::GatherDir.exclude_match[0] = ^src/

--- a/dist.ini
+++ b/dist.ini
@@ -48,7 +48,7 @@ package = DB    ; just in case
 
 [ExtraTests]
 [RunExtraTests]
-[NoTabsTests]
+[Test::NoTabs]
 [EOLTests]
 [Test::Version]
 [MetaTests]


### PR DESCRIPTION
This PR fixes warnings from `Dist::Zilla` concerning deprecated plugins.  It works around an issue with the upstream INGY `Dist::Zilla` bundle and replaces the `NoTabsTests` plugin with its recommended replacement.

If you have any questions or comments concerning this PR, please just let me know.  If any changes are required, I can update the PR and resubmit.