### PR TITLE
Update copyright year

### DIFF
--- a/lib/Mo.pod
+++ b/lib/Mo.pod
@@ -128,7 +128,7 @@ Carlos Lima (priodev) <carlos@cpan.org>
 
 =head1 Copyright and License
 
-Copyright (c) 2011-2013. Ingy döt Net.
+Copyright (c) 2011-2016. Ingy döt Net.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.

--- a/lib/Mo/Golf.pm
+++ b/lib/Mo/Golf.pm
@@ -3,7 +3,7 @@
 # abstract:  Module for Compacting Mo Modules
 # author:    Ingy döt Net <ingy@ingy.net>
 # license:   perl
-# copyright: 2011
+# copyright: 2016
 # see:
 # - Mo
 

--- a/lib/Mo/Golf.pm
+++ b/lib/Mo/Golf.pm
@@ -3,7 +3,7 @@
 # abstract:  Module for Compacting Mo Modules
 # author:    Ingy döt Net <ingy@ingy.net>
 # license:   perl
-# copyright: 2016
+# copyright: 2011-2016
 # see:
 # - Mo
 

--- a/lib/Mo/Inline.pm
+++ b/lib/Mo/Inline.pm
@@ -3,7 +3,7 @@
 # abstract:  Inline Mo and Features into your package
 # author:    Ingy döt Net <ingy@ingy.net>
 # license:   perl
-# copyright: 2016
+# copyright: 2011-2016
 # see:
 # - Mo
 

--- a/lib/Mo/Inline.pm
+++ b/lib/Mo/Inline.pm
@@ -3,7 +3,7 @@
 # abstract:  Inline Mo and Features into your package
 # author:    Ingy döt Net <ingy@ingy.net>
 # license:   perl
-# copyright: 2011
+# copyright: 2016
 # see:
 # - Mo
 

--- a/xt/module-install/README
+++ b/xt/module-install/README
@@ -5,7 +5,7 @@ AUTHORS
     Ingy döt Net <ingy@cpan.org>
 
 COPYRIGHT AND LICENSE
-    Copyright (c) 2016. Ingy döt Net.
+    Copyright (c) 2011-2016. Ingy döt Net.
 
     This program is free software; you can redistribute it and/or modify it
     under the same terms as Perl itself.

--- a/xt/module-install/README
+++ b/xt/module-install/README
@@ -5,7 +5,7 @@ AUTHORS
     Ingy döt Net <ingy@cpan.org>
 
 COPYRIGHT AND LICENSE
-    Copyright (c) 2011. Ingy döt Net.
+    Copyright (c) 2016. Ingy döt Net.
 
     This program is free software; you can redistribute it and/or modify it
     under the same terms as Perl itself.

--- a/xt/module-install/lib/Foo.pm
+++ b/xt/module-install/lib/Foo.pm
@@ -15,7 +15,7 @@ Ingy döt Net <ingy@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (c) 2011. Ingy döt Net.
+Copyright (c) 2016. Ingy döt Net.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.

--- a/xt/module-install/lib/Foo.pm
+++ b/xt/module-install/lib/Foo.pm
@@ -15,7 +15,7 @@ Ingy döt Net <ingy@cpan.org>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (c) 2016. Ingy döt Net.
+Copyright (c) 2011-2016. Ingy döt Net.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.


### PR DESCRIPTION
Update copyright year information in all source files.  This PR is split into two commits since it might be preferable not to update the information within the `xt/module-install` directory, hence one can simply the cherry-pick the changes as required.