### PR TITLE
Change wording of initial comment of Mo.pm

### DIFF
--- a/src/Mo.pm
+++ b/src/Mo.pm
@@ -1,4 +1,4 @@
-# The first two lines are left alone in the compressed source.
+# The following two lines are left alone in the compressed source.
 package Mo;
 $VERSION='0.40';
 


### PR DESCRIPTION
Initial comment seemed to indicate that the comment itself was preserved.  Changed the wording so that it is clear that the two lines following the comment are what is being preserved.