### PR TITLE
Add NAME sections so documentation can be found by metacpan

### DIFF
--- a/lib/Mo/Golf.pm
+++ b/lib/Mo/Golf.pm
@@ -225,6 +225,10 @@ sub _finder_subs {
     );
 }
 
+=head1 NAME
+
+Mo::Golf - Module for Compacting Mo Modules
+
 =head1 SYNOPSIS
 
     perl -MMo::Golf=golf < src/Mo/foo.pm > lib/Mo/foo.pm

--- a/lib/Mo/Inline.pm
+++ b/lib/Mo/Inline.pm
@@ -92,6 +92,10 @@ Usage: mo-linline <perl module files or directories>
 
 1;
 
+=head1 NAME
+
+Mo::Inline - Inline Mo and Features into your package
+
 =head1 SYNOPSIS
 
 In your Mo module:


### PR DESCRIPTION
I am not sure if something is supposed to be preprocessing this, but Mo::Inline and Mo::Golf documentation lacks a properly formatted NAME section, so the documentation is not accessible under those names on metacpan.