### PR TITLE
Move Moose and Mouse to suggests

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -62,6 +62,8 @@ perl = 5.6.0
 [Prereqs / Recommends]
 Class::XSAccessor = 0
 IO::All = 0
+
+[Prereqs / Suggests]
 Moose = 0
 Mouse = 0
 


### PR DESCRIPTION
IO::All and Class::XSAccessor provide useful functionality for Mo, but Moose and Mouse are only useful if you actually want to use Moose and Mouse (whether by the Mo wrapper or not). They are also somewhat heavy dependencies (well, Moose is) for a presumably rare use case. Thus in my opinion suggests is a better fit.